### PR TITLE
go-eicio: Fixed failure to retrieve event at EOF for gzip files

### DIFF
--- a/go-eicio/eicio-summary/main.go
+++ b/go-eicio/eicio-summary/main.go
@@ -16,7 +16,7 @@ var (
 
 func printUsage() {
 	fmt.Fprintf(os.Stderr,
-		`Usage: eicio-ls [options] <eicio-input-file>
+		`Usage: eicio-summary [options] <eicio-input-file>
 options:
 `,
 	)
@@ -50,16 +50,20 @@ func main() {
 	}
 	defer reader.Close()
 
-	var event *eicio.Event
-	for event, err = reader.Next(); event != nil; event, err = reader.Next() {
+	nEvents := 0
+
+	var header *eicio.EventHeader
+	for header, err = reader.NextHeader(); header != nil; header, err = reader.NextHeader() {
 		if err != nil {
 			log.Print(err)
 		}
 
-		fmt.Print(event)
+		nEvents++
 	}
 
 	if err != nil && err != io.EOF {
 		log.Print(err)
 	}
+
+	fmt.Println("Number of events:", nEvents)
 }

--- a/go-eicio/writer.go
+++ b/go-eicio/writer.go
@@ -66,7 +66,6 @@ func NewGzipWriter(byteWriter io.Writer) (*Writer, error) {
 	}
 
 	writer := NewWriter(gzWriter)
-	writer.deferUntilClose(gzWriter.Flush)
 	writer.deferUntilClose(gzWriter.Close)
 
 	return writer, nil


### PR DESCRIPTION
The gzip reader can return successfully and also give EOF error.  This
is now handled properly.  The bug was hidden by the fact that I had
forced gzip to do an extra flush before closing in write routine, which
made the gzip reader not return EOF until the next read (pointed out by @sbinet in #3).

This PR resolves #10.