### PR TITLE
go-eicio: Added channel iterator for reader

### DIFF
--- a/go-eicio/eicio-ls/main.go
+++ b/go-eicio/eicio-ls/main.go
@@ -66,10 +66,9 @@ func main() {
 
 	nEventsRead := 0
 
-	var event *eicio.Event
-	for event, err = reader.Get(); event != nil; event, err = reader.Get() {
-		if err != nil {
-			log.Print(err)
+	for event := range reader.Events() {
+		if reader.Err != nil {
+			log.Print(reader.Err)
 		}
 
 		fmt.Print(event)
@@ -80,7 +79,7 @@ func main() {
 		}
 	}
 
-	if (err != nil && err != io.EOF) || nEventsRead == 0 {
-		log.Print(err)
+	if (reader.Err != nil && reader.Err != io.EOF) || nEventsRead == 0 {
+		log.Print(reader.Err)
 	}
 }

--- a/go-eicio/eicio-strip/main.go
+++ b/go-eicio/eicio-strip/main.go
@@ -77,10 +77,9 @@ func main() {
 
 	nEventsRead := 0
 
-	var event *eicio.Event
-	for event, err = reader.Get(); event != nil; event, err = reader.Get() {
-		if err != nil {
-			log.Print(err)
+	for event := range reader.Events() {
+		if reader.Err != nil {
+			log.Print(reader.Err)
 		}
 
 		for _, collName := range event.GetNames() {
@@ -111,7 +110,7 @@ func main() {
 		nEventsRead++
 	}
 
-	if (err != nil && err != io.EOF) || nEventsRead == 0 {
-		log.Print(err)
+	if (reader.Err != nil && reader.Err != io.EOF) || nEventsRead == 0 {
+		log.Print(reader.Err)
 	}
 }


### PR DESCRIPTION
New method Reader.Events() returns <-chan Event to provide simple syntax
for ranging over all events in a file/stream.  Reader.Err was added to
make errors accessible in this scheme.

Additionally, the tools `eicio-ls` and `eicio-strip` were updated to iterate events in this way.

This PR resolves #34 